### PR TITLE
if reminder date is in the past, assume intended date is tomorrow

### DIFF
--- a/source/info.plist
+++ b/source/info.plist
@@ -543,10 +543,15 @@ function parseReminderQuery(query) {
   }
 
 	results = window.chrono.parse(query);
+	var now = new Date();
 	
 	for (var i = 0; i &lt; results.length; i++) {
 		resultText = query.replace(results[i].text,'');
 		var d = results[i].start.date(); // Create a Date object
+		// If date is in the past, assume intended date is tomorrow
+		if (d &lt; now) {
+			d.setDate(now.getDate() + 1);
+		}
 		var reminderText = resultText.trim();
 		items.push(getAction({arg:i, valid:true, reminderText:reminderText, date:d, whenText:results[i].text, priority:priority, reminderList:reminderList}));
 		reminders.push(getReminderData({arg:i, reminderText:reminderText, reminderBody:reminderBody, date:d, list:"", priority:priority, application:application, reminderList:reminderList}));


### PR DESCRIPTION
In the use case where a reminder query is typed containing date information, but the date consists of only a time (e.g. 'r go to store 7am'), it makes more sense (and it's more in line with reminder creation via Siri) for the date to be assumed to be '7am tomorrow' _if_ the parsed time has already elapsed today.

Example:
>It is currently 1pm, and I enter 'r pick up the laundry at 8am'. This is parsed as Create reminder titled 'pick up the laundry' scheduled for 7am today. In this case, since it's past 7am, it's safe to assume that tomorrow was implied, and the reminder should instead be created for tomorrow at 7am.

This change checks if the parsed date and time is before the current date and time, and if so corrects the date to be tomorrow.