### PR TITLE
Fix chrono.js loading on macOS Tahoe (eval scope change)

### DIFF
--- a/source/info.plist
+++ b/source/info.plist
@@ -206,6 +206,8 @@ end alfred_script</string>
 				<string>ObjC.import('Foundation');
 ObjC.import('stdlib');
 var window = {} // required for chrono.js to function properly, see https://github.com/wanasit/chrono/issues/34
+var module = {exports: {}};
+var exports = module.exports;
 
 function run(argv) {
 	var query = argv[0],
@@ -238,8 +240,6 @@ function createChronoInstance() {
     var contents = fm.contentsAtPath(chronoPath);
     contents = $.NSString.alloc.initWithDataEncoding(contents, $.NSUTF8StringEncoding);
 
-    var module = {exports: {}};
-    var exports = module.exports;
     eval(ObjC.unwrap(contents));
     return module.exports;
 }
@@ -677,6 +677,8 @@ function showHelpItems() {
 				<string>ObjC.import('Foundation');
 ObjC.import('stdlib');
 var window = {} // required for chrono.js to function properly, see https://github.com/wanasit/chrono/issues/34
+var module = {exports: {}};
+var exports = module.exports;
 
 function run(argv) {
 	var query = argv[0],
@@ -709,8 +711,6 @@ function createChronoInstance() {
     var contents = fm.contentsAtPath(chronoPath);
     contents = $.NSString.alloc.initWithDataEncoding(contents, $.NSUTF8StringEncoding);
 
-    var module = {exports: {}};
-    var exports = module.exports;
     eval(ObjC.unwrap(contents));
     return module.exports;
 }


### PR DESCRIPTION
## Summary

macOS 26 (Tahoe) changed how JXA's `eval()` resolves variable scope, breaking chrono.js loading. This PR fixes it by moving `var module` and `var exports` from function scope to global scope.

### Root cause

In `parseReminderQuery()`, chrono.js is loaded via `eval()` with `module` and `exports` as function-local variables. On Tahoe, `eval()` can no longer see these locals — so `window.chrono` ends up as an empty object with no `.parse()` method, and the script filter silently returns no results.

### Fix

Move the two declarations to global scope (alongside `var window = {}`) in both JXA scripts (Script Filter and External Trigger). Remove the now-redundant local declarations from inside `parseReminderQuery()`.

### Testing

- Tested on macOS 26.4 (build 25E246) with Alfred 5.7.2
- Date parsing, reminder creation, hotkey trigger, and `r help` all work
- Backwards compatible — global-scope `module`/`exports` works on older macOS too

Fixes #141